### PR TITLE
認証機能の作成に伴うgemの導入 close #6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,13 @@ gem 'bootsnap', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# 認証系
+gem 'omniauth'
+gem "omniauth-rails_csrf_protection"
+gem 'omniauth-github'
+
+# 環境変数
+gem 'dotenv-rails'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
+end

--- a/render.yml
+++ b/render.yml
@@ -1,12 +1,12 @@
 databases:
-  - name: GithubBattle_DB
-    databaseName: githubbattle
-    user: GithubBattle
+  - name: GrassBattle_DB
+    databaseName: grassbattle
+    user: GrassBattle
     region: singapore
 
 services:
   - type: web
-    name: GithubBattle
+    name: GrassBattle
     env: ruby
     region: singapore
     plan: free
@@ -15,7 +15,7 @@ services:
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: GithubBattle_DB
+          name: GrassBattle_DB
           property: connectionString
       - key: RAILS_MASTER_KEY
         sync: false


### PR DESCRIPTION
## ブランチ名
feature/omniauth-gem

## 概要
omniauthに必要なgemの導入

## 目的 
omniauthの導入で認証機能の作成を行うため。

## 確認ポイント

- [x] omniauthのgemを入れる
- [x] omniauthのプロテクテクトようのgemを入れる
- [x] omniauthのgithubのgemを入れる

※追加

- [x]  dotenv-railsの導入

## 補足
環境変数を扱うことからdotenv-railsも導入しています。