### PR TITLE
 経験値取得履歴用のDB作成 close #22

### DIFF
--- a/app/models/experience_log.rb
+++ b/app/models/experience_log.rb
@@ -1,0 +1,3 @@
+class ExperienceLog < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20240626234127_create_experience_logs.rb
+++ b/db/migrate/20240626234127_create_experience_logs.rb
@@ -1,0 +1,10 @@
+class CreateExperienceLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :experience_logs do |t|
+      t.integer :earned_experience_points
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_15_050926) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_26_234127) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "experience_logs", force: :cascade do |t|
+    t.integer "earned_experience_points"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_experience_logs_on_user_id"
+  end
 
   create_table "user_authentications", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -42,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_15_050926) do
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end
 
+  add_foreign_key "experience_logs", "users"
   add_foreign_key "user_authentications", "users"
   add_foreign_key "user_statuses", "users"
 end

--- a/test/fixtures/experience_logs.yml
+++ b/test/fixtures/experience_logs.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  earned_experience_points: 1
+  user: one
+
+two:
+  earned_experience_points: 1
+  user: two

--- a/test/models/experience_log_test.rb
+++ b/test/models/experience_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExperienceLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## ブランチ名
feature/exp-logs-db

## 概要
経験値として取得したデータの履歴を保存してください。

## 目的 
経験値として取得したデータをユーザーに表示させるため。

## 確認ポイント

- [x] 経験値のデータを保存すためのDBを追加してください

## 補足
当初のブランチ名はfeature/exp-history-dbでしたが、feature/exp-logs-dbに変更しています。