### PR TITLE
 経験値履歴のデータ送信 close #24

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::UsersController < ApplicationController
   def home
-    render json: @current_user, status: :ok, each_serializer: UserSerializer
+    @experience_logs = @current_user.user_status.experience_logs.order(created_at: :desc).limit(30)
+
+    render json: {
+      current_user: ActiveModelSerializers::SerializableResource.new(@current_user, serializer: UserSerializer),
+      experience_logs: ActiveModelSerializers::SerializableResource.new(@experience_logs, each_serializer: ExperienceLogSerializer),
+    }, status: :ok
   end
 end

--- a/app/models/concerns/create_user_status.rb
+++ b/app/models/concerns/create_user_status.rb
@@ -24,6 +24,7 @@ module CreateUserStatus
     # ユーザーが登録した際にプロフィールを作成
     UserStatus.create!(user_id: user.id)
 
+
     # githubに対してgraphqlリクエストを送信
     response = GitHubClient::Client.query(Api::V1::GraphqlController::Query,
                                           variables: { name: user.github_id,
@@ -50,6 +51,9 @@ module CreateUserStatus
 
     # 次回の経験値の計算の際、前日のコントリビューション数を保存するためのデータ
     temporal_contributions = all_contributions - oldest_date_contributions
+
+    # 経験値の保存
+    user.user_status.experience_logs.create!(earned_experience_points: experience_point_data)
 
     # レベルの計算
     level_data = user.user_status.level

--- a/app/models/experience_log.rb
+++ b/app/models/experience_log.rb
@@ -1,3 +1,3 @@
 class ExperienceLog < ApplicationRecord
-  belongs_to :user
+  belongs_to :user_status
 end

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -1,4 +1,5 @@
 class UserStatus < ApplicationRecord
+  has_many :experience_logs
   belongs_to :user
 
   validates :level, presence: true

--- a/app/serializers/experience_log_serializer.rb
+++ b/app/serializers/experience_log_serializer.rb
@@ -1,0 +1,3 @@
+class ExperienceLogSerializer < ActiveModel::Serializer
+  attributes :id, :earned_experience_points, :created_at
+end

--- a/db/migrate/20240627073035_create_experience_logs.rb
+++ b/db/migrate/20240627073035_create_experience_logs.rb
@@ -1,8 +1,8 @@
 class CreateExperienceLogs < ActiveRecord::Migration[7.0]
   def change
     create_table :experience_logs do |t|
-      t.integer :earned_experience_points
-      t.references :user, null: false, foreign_key: true
+      t.integer :earned_experience_points, null: false, default: 0
+      t.references :user_status, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_26_234127) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_27_073035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "experience_logs", force: :cascade do |t|
-    t.integer "earned_experience_points"
-    t.bigint "user_id", null: false
+    t.integer "earned_experience_points", default: 0, null: false
+    t.bigint "user_status_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_experience_logs_on_user_id"
+    t.index ["user_status_id"], name: "index_experience_logs_on_user_status_id"
   end
 
   create_table "user_authentications", force: :cascade do |t|
@@ -50,7 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_234127) do
     t.index ["github_id"], name: "index_users_on_github_id", unique: true
   end
 
-  add_foreign_key "experience_logs", "users"
+  add_foreign_key "experience_logs", "user_statuses"
   add_foreign_key "user_authentications", "users"
   add_foreign_key "user_statuses", "users"
 end

--- a/lib/tasks/update_status_task.rake
+++ b/lib/tasks/update_status_task.rake
@@ -98,6 +98,8 @@ namespace :update_status_task do
       # 次回の経験値の計算の際、前日のコントリビューション数を保存するためのデータ
       temporal_contributions = all_contributions - oldest_date_contributions
 
+      user.user_status.experience_logs.create!(earned_experience_points: experience_point_data)
+
       # 経験値が1以上の場合、経験値を加算する
       if experience_point_data.positive?
 

--- a/test/fixtures/experience_logs.yml
+++ b/test/fixtures/experience_logs.yml
@@ -2,8 +2,8 @@
 
 one:
   earned_experience_points: 1
-  user: one
+  user_status: one
 
 two:
   earned_experience_points: 1
-  user: two
+  user_status: two


### PR DESCRIPTION
## ブランチ名
feature/exp-data-sending

## 概要
経験値履歴のデータ送信を行なってください。

## 目的 
経験値履歴のデータをフロント側で表示するため

## 確認ポイント

- [x] 経験値履歴のデータがフロント側に送信されているか

## 補足
以前作成していた経験値履歴テーブルがuser_statusテーブルではなく、userテーブルに紐づいていたため修正を行いました。