### PR TITLE
戦闘力グラフ用データ保存

### DIFF
--- a/app/models/concerns/create_user_status.rb
+++ b/app/models/concerns/create_user_status.rb
@@ -18,6 +18,7 @@ module CreateUserStatus
       end
     end
     user.user_status.update(week_contributions: week_contribution_data)
+    user.user_status.week_contribution_histories.create!(week_contributions: week_contribution_data)
   end
 
   def set_experience_points(user)

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -1,5 +1,6 @@
 class UserStatus < ApplicationRecord
   has_many :experience_histories
+  has_many :week_contribution_histories
   belongs_to :user
 
   validates :level, presence: true

--- a/db/migrate/20240702062212_create_week_contribution_histories.rb
+++ b/db/migrate/20240702062212_create_week_contribution_histories.rb
@@ -2,7 +2,7 @@ class CreateWeekContributionHistories < ActiveRecord::Migration[7.0]
   def change
     create_table :week_contribution_histories do |t|
       t.references :user_status, null: false, foreign_key: true
-      t.integer :week_contribution, null: false, default: 0
+      t.integer :week_contributions, null: false, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_02_062212) do
 
   create_table "week_contribution_histories", force: :cascade do |t|
     t.bigint "user_status_id", null: false
-    t.integer "week_contribution", default: 0, null: false
+    t.integer "week_contributions", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_status_id"], name: "index_week_contribution_histories_on_user_status_id"

--- a/lib/tasks/update_status_task.rake
+++ b/lib/tasks/update_status_task.rake
@@ -70,6 +70,7 @@ namespace :update_status_task do
 
       # ユーザーデータの更新
       user.user_status.update!(week_contributions: contributions)
+      user.user_status.week_contribution_histories.create!(week_contributions: contributions)
     end
   end
 


### PR DESCRIPTION
## ブランチ名
feature/create-power-graph-data

## 概要
戦闘力グラフ作成用のデータを保存するための処理を作成してください。
処理はupdate_status_task.rakeファイルとcontrollerにあるcreate_user_statusファイルに追加してください。

## 目的 
戦闘力グラフを作成することによってユーザーが学習を行ってきた経過がわかりやすくなるため

## 確認ポイント

- [x] week_contributionがweek_contribution_historiesのweek_contributionsに保存されているか

## 補足