### PR TITLE
戦闘力グラフ用データ送信 close #31

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::UsersController < ApplicationController
   def home
     @experience_histories = @current_user.user_status.experience_histories.order(created_at: :desc).limit(30)
+    @week_contribution_histories = @current_user.user_status.week_contribution_histories.order(created_at: :desc).limit(7)
 
     render json: {
       current_user: ActiveModelSerializers::SerializableResource.new(@current_user, serializer: UserSerializer),
       experience_histories: ActiveModelSerializers::SerializableResource.new(@experience_histories, each_serializer: ExperienceHistorySerializer),
+      week_contribution_histories: ActiveModelSerializers::SerializableResource.new(@week_contribution_histories, each_serializer: WeekContributionHistorySerializer)
     }, status: :ok
   end
 end

--- a/app/serializers/week_contribution_history_serializer.rb
+++ b/app/serializers/week_contribution_history_serializer.rb
@@ -1,0 +1,3 @@
+class WeekContributionHistorySerializer < ActiveModel::Serializer
+  attributes :id, :week_contributions, :created_at
+end


### PR DESCRIPTION
## ブランチ名
feature/power-graph-data-sending

## 概要
戦闘力グラフを作成するためのデータをフロント側に送信してください。
送信する際にはlimitを使用して直近の７つのデータを送るようにしてください。
また、データの送信時には不要なファイルを送らないためにserializersを使用して送信を行なってください。

## 目的 
戦闘力グラフを作成するにあたって、データの送信をフロント側にする必要があるため

## 確認ポイント

- [x] 戦闘力データが送信されているか
- [x] serializerを使用しているか
- [x] serializerによって不要なデータが送られていないか
- [x] データは直近の７つのデータが送信されているか

## 補足