### PR TITLE
 アバター情報の保存処理及び新規登録機能の修正 close #44

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,11 +3,15 @@ class Api::V1::UsersController < ApplicationController
     @experience_histories = @current_user.user_status.experience_histories.order(created_at: :desc).limit(30)
     @week_contribution_histories = @current_user.user_status.week_contribution_histories.order(created_at: :desc).limit(7)
     @week_contribution_histories_asc = @week_contribution_histories.reverse
+    @avatar_count = Avatar.all.count
 
     render json: {
       current_user: ActiveModelSerializers::SerializableResource.new(@current_user, serializer: UserSerializer),
-      experience_histories: ActiveModelSerializers::SerializableResource.new(@experience_histories, each_serializer: ExperienceHistorySerializer),
-      week_contribution_histories: ActiveModelSerializers::SerializableResource.new(@week_contribution_histories_asc, each_serializer: WeekContributionHistorySerializer)
+      experience_histories: ActiveModelSerializers::SerializableResource.new(@experience_histories,
+                                                                             each_serializer: ExperienceHistorySerializer),
+      week_contribution_histories: ActiveModelSerializers::SerializableResource.new(@week_contribution_histories_asc,
+                                                                                    each_serializer: WeekContributionHistorySerializer),
+      avatar_count: @avatar_count
     }, status: :ok
   end
 
@@ -19,8 +23,10 @@ class Api::V1::UsersController < ApplicationController
 
     render json: {
       user: ActiveModelSerializers::SerializableResource.new(user, serializer: UserSerializer),
-      experience_histories: ActiveModelSerializers::SerializableResource.new(experience_histories, each_serializer: ExperienceHistorySerializer),
-      week_contribution_histories: ActiveModelSerializers::SerializableResource.new(week_contribution_histories_asc, each_serializer: WeekContributionHistorySerializer)
+      experience_histories: ActiveModelSerializers::SerializableResource.new(experience_histories,
+                                                                             each_serializer: ExperienceHistorySerializer),
+      week_contribution_histories: ActiveModelSerializers::SerializableResource.new(week_contribution_histories_asc,
+                                                                                    each_serializer: WeekContributionHistorySerializer)
     }, status: :ok
   end
 
@@ -34,6 +40,6 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name)
+    params.require(:user).permit(:name, :avatar_id)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,11 +20,12 @@ class SessionsController < ApplicationController
       redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
     else
       # ユーザー情報が存在しない場合はユーザー情報を作成してトークンを返却
-      user = User.create(name: 'GRASS BATTLE MEMBER', github_uid: github_uid_info)
+      user = User.create(name: 'GRASS BATTLE MEMBER', github_uid: github_uid_info, avatar_id: 1)
       UserAuthentication.create(user_id: user.id, uid: uid_info)
 
       set_experience_points(user)
       set_contributions(user)
+      set_initial_experience_points(user)
 
       redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
 

--- a/app/models/concerns/jwt_authenticator.rb
+++ b/app/models/concerns/jwt_authenticator.rb
@@ -25,13 +25,13 @@ module JwtAuthenticator
 
   # 暗号化処理
   def encode_access_token(uid_info)
-    exp_info = Time.now.to_i + 900
+    exp_info = Time.now.to_i + 12 * 3600
     payload = { uid: uid_info, exp: exp_info }
     JWT.encode(payload, ENV['JWT_SECRET_KEY'], 'HS256')
   end
 
   def encode_refresh_token(uid_info)
-    exp_info = Time.now.to_i + 24 * 3600
+    exp_info = Time.now.to_i + 7 * 24 * 3600
     payload = { uid: uid_info, exp: exp_info }
     JWT.encode(payload, ENV['JWT_SECRET_KEY'], 'HS256')
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
   has_many :user_status, serializer: UserStatusSerializer
 
-  attributes :id, :name
+  attributes :id, :name, :avatar_id
 end

--- a/db/migrate/20240708034509_create_avatars.rb
+++ b/db/migrate/20240708034509_create_avatars.rb
@@ -1,7 +1,7 @@
 class CreateAvatars < ActiveRecord::Migration[7.0]
   def change
     create_table :avatars do |t|
-      t.integer :name, null: false
+      t.string :name, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_08_041435) do
   enable_extension "plpgsql"
 
   create_table "avatars", force: :cascade do |t|
-    t.integer "name", null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,8 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 #
+initial_avatars = ['剣士（男）', '剣士（女）', '魔法使い（女）', '魔法使い（男）', '騎士']
+
+initial_avatars.each do |avatar|
+  Avatar.create(name: avatar)
+end


### PR DESCRIPTION
## ブランチ名
feature/avatar-settings

## 概要
アバター設定にてフロント側から送られてきたアバターの選択を行ってください。

## 目的 
アバターの設定においてDB上に保存する必要があることから設定を行う

## 確認ポイント

- [x] フロント側で設定したデータが適切に保存できているか

## 補足
プロトタイプで遊んでいただいた方のために新規登録時に5月15日のレベルアップ機能実装日からの経験値の追加を行えるように修正を行いました。