### PR TITLE
[fix] ユーザーの名前の文字数を制限

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
       redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
     else
       # ユーザー情報が存在しない場合はユーザー情報を作成してトークンを返却
-      user = User.create(name: 'GRASS BATTLE MEMBER', github_uid: github_uid_info, avatar_id: 1)
+      user = User.create(name: 'MEMBER', github_uid: github_uid_info, avatar_id: 1)
       UserAuthentication.create(user_id: user.id, uid: uid_info)
 
       set_experience_points(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   has_one :user_status, dependent: :destroy
   belongs_to :avatar, optional: true
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 10 }
   validates :github_uid, presence: true, uniqueness: true
 end

--- a/db/migrate/20240711082400_change_column_to_user.rb
+++ b/db/migrate/20240711082400_change_column_to_user.rb
@@ -1,6 +1,6 @@
 class ChangeColumnToUser < ActiveRecord::Migration[7.0]
   def up
-    change_column :users, :name, :string, null: false, default: 'MEMBER'
+    change_column :users, :name, :string, null: false, default: 'MEMBER', maxlength: 10
   end
 
   def down

--- a/db/migrate/20240711082400_change_column_to_user.rb
+++ b/db/migrate/20240711082400_change_column_to_user.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToUser < ActiveRecord::Migration[7.0]
+  def up
+    change_column :users, :name, :string, null: false, default: 'MEMBER'
+  end
+
+  def down
+    change_column :users, :name, :string, null: false, default: 'GRASS BATTLE MEMBER'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_08_041435) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_11_082400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_08_041435) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", default: "GRASS BATTLE MEMBER", null: false
+    t.string "name", default: "MEMBER", null: false
     t.string "github_uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
文字数制限に伴って、バリデーションと初期の名前変更、ファイルの変更をしています。