### PR TITLE
[fix] ユーザーのステータス情報が初期化されるバグを修正

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,47 +3,34 @@ class SessionsController < ApplicationController
   include CreateUserStatus
 
   def create
-    # githubから情報を取得
     user_info = request.env['omniauth.auth']
     raise 'GitHub情報の取得に失敗しました' unless user_info
 
-    # ユーザー情報を取得
     uid_info = user_info['uid']
     github_uid_info = user_info['info']['nickname']
     token_info = encode_access_token(uid_info)
 
-    # ユーザー情報が存在するか確認
     user_auth = UserAuthentication.find_by(uid: uid_info)
 
-    if user_auth
-      # ユーザー情報が存在する場合はトークンを返却
-      redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
-    else
-      # ユーザー情報が存在しない場合はユーザー情報を作成してトークンを返却
+    unless user_auth
       user = User.create(name: 'MEMBER', github_uid: github_uid_info, avatar_id: 1)
       UserAuthentication.create(user_id: user.id, uid: uid_info)
 
       set_experience_points(user)
       set_contributions(user)
-      set_initial_experience_points(user)
-
-      redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
-
+      initial_experience_points(user)
     end
+    redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
   rescue StandardError => e
-    # エラーが発生した場合はログを出力してエラーを返却
     Rails.logger.error("認証エラー: #{e.message}")
     redirect_to "#{ENV['FRONT_URL']}?error=authentication_failed"
   end
 
   def update
-    # トークンを再発行
     access_token_info = encode_access_token(@current_user.user_authentication[:uid])
     refresh_token_info = encode_refresh_token(@current_user.user_authentication[:uid])
-    # トークンを返却
     render json: { access_token: access_token_info, refresh_token: refresh_token_info }, status: :ok
   rescue StandardError => e
-    # エラーが発生した場合はログを出力してエラーを返却
     Rails.logger.error("認証エラー: #{e.message}")
     render json: { error: 'authentication_failed' }, status: :unauthorized
   end

--- a/app/models/concerns/create_user_status.rb
+++ b/app/models/concerns/create_user_status.rb
@@ -22,44 +22,32 @@ module CreateUserStatus
   end
 
   def set_experience_points(user)
-    # ユーザーが登録した際にプロフィールを作成
     UserStatus.create!(user_id: user.id)
 
-
-    # githubに対してgraphqlリクエストを送信
     response = GitHubClient::Client.query(Api::V1::GraphqlController::Query,
                                           variables: { name: user.github_uid,
                                                        to: Time.current.yesterday.end_of_day.iso8601,
                                                        from: Time.current.ago(30.days).beginning_of_day.iso8601 })
 
-    # 一番新しい日にちのコントリビューション数
     latest_date_contributions = response.original_hash.dig('data', 'user', 'contributionsCollection',
                                                            'contributionCalendar', 'weeks', -1, 'contributionDays', -1, 'contributionCount')
 
-    # 一番古い日にちのコントリビューション数
     oldest_date_contributions = response.original_hash.dig('data', 'user', 'contributionsCollection', 'contributionCalendar',
                                                            'weeks', 0, 'contributionDays', 0, 'contributionCount')
 
-    # 約１ヶ月分全てのコントリビューション数
     all_contributions = response.original_hash.dig('data', 'user', 'contributionsCollection', 'contributionCalendar',
                                                    'totalContributions')
 
-    # データがない場合にはスキップ
     return if all_contributions.blank?
 
-    # 経験値の計算
     experience_point_data = latest_date_contributions
 
-    # 次回の経験値の計算の際、前日のコントリビューション数を保存するためのデータ
     temporal_contributions = all_contributions - oldest_date_contributions
 
-    # 経験値の保存
     user.user_status.experience_histories.create!(earned_experience_points: experience_point_data)
 
-    # レベルの計算
     level_data = user.user_status.level
 
-    # 経験値が10以上の場合、レベルアップする
     if experience_point_data >= 10
       experience_point_data %= 10
       level_data += (experience_point_data / 10).ceil
@@ -71,34 +59,26 @@ module CreateUserStatus
     end
   end
 
-  def set_initial_experience_points(user)
-    # ユーザーが登録した際にプロフィールを作成
-    UserStatus.create!(user_id: user.id)
-
-    # githubに対してgraphqlリクエストを送信
+  def initial_experience_points(user)
     response = GitHubClient::Client.query(Api::V1::GraphqlController::Query,
                                           variables: { name: user.github_uid,
                                                        to: Time.current.ago(2.days).end_of_day.iso8601,
                                                        from: Time.new(2024, 5, 15).iso8601 })
-    # 約１ヶ月分全てのコントリビューション数
     all_contributions = response.original_hash.dig('data', 'user', 'contributionsCollection', 'contributionCalendar',
                                                    'totalContributions')
 
-    # データがない場合にはスキップ
     return if all_contributions.blank?
 
     experience_point_data = user.user_status.experience_points + all_contributions
 
-    # レベルの計算
     level_data = user.user_status.level
 
-    # 経験値が10以上の場合、レベルアップする
     if experience_point_data >= 10
       experience_point_data %= 10
       level_data += (all_contributions / 10).ceil
       user.user_status.update!(level: level_data, experience_points: experience_point_data)
     else
-      user.user_status.update( experience_points: experience_point_data)
+      user.user_status.update(experience_points: experience_point_data)
     end
   end
 end

--- a/app/models/concerns/jwt_authenticator.rb
+++ b/app/models/concerns/jwt_authenticator.rb
@@ -23,7 +23,6 @@ module JwtAuthenticator
     @current_user
   end
 
-  # 暗号化処理
   def encode_access_token(uid_info)
     exp_info = Time.now.to_i + 12 * 3600
     payload = { uid: uid_info, exp: exp_info }
@@ -36,7 +35,6 @@ module JwtAuthenticator
     JWT.encode(payload, ENV['JWT_SECRET_KEY'], 'HS256')
   end
 
-  # 復号化処理
   def decode(encoded_token)
     decoded_token = JWT.decode(encoded_token, ENV['JWT_SECRET_KEY'], true, algorithm: 'HS256')
     decoded_token.first

--- a/db/migrate/20240711082400_change_column_to_user.rb
+++ b/db/migrate/20240711082400_change_column_to_user.rb
@@ -1,6 +1,6 @@
 class ChangeColumnToUser < ActiveRecord::Migration[7.0]
   def up
-    change_column :users, :name, :string, null: false, default: 'MEMBER', maxlength: 10
+    change_column :users, :name, :string, null: false, default: 'MEMBER'
   end
 
   def down


### PR DESCRIPTION
ユーザーが10人を超えると発生するバグを修正しました。
私のコード記載のミスでuserに紐づくuser_statusデータが二つできてしまうようした。